### PR TITLE
(refs #9)Set maxsize of autoscaling group to avoid scale out when an argument of capacity is not empty

### DIFF
--- a/scripts/autoscaling/create_group.coffee
+++ b/scripts/autoscaling/create_group.coffee
@@ -70,6 +70,7 @@ module.exports = (robot) ->
     params.LaunchConfigurationName = conf
     params.DesiredCapacity         = capacity
     params.MinSize                 = capacity
+    params.MaxSize                 = capacity
 
     if dry_run
       msg.send util.inspect(params, false, null)


### PR DESCRIPTION
see https://github.com/yoheimuta/hubot-aws/issues/9
