### PR TITLE
Upgrade moment to 2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "async": "0.9.0",
     "underscore": "1.8.3",
     "cson": "3.0.1",
-    "moment": "2.10.2"
+    "moment": "2.13.0"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
2.10.2 is insecure version of Moment.js, so should upgrade to the latest version.
https://nodesecurity.io/advisories/moment_regular-expression-denial-of-service
